### PR TITLE
Change default urls and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CTA data are/will be stored at CTAO-CH data center at CSCS.
 These data should be accessible for selected external users.
 In addition, these files should be available within interactive analysis platform at CSCS.
 This client presents an API access to these services and data.
+
 ## Installation
 
 ```bash
@@ -53,13 +54,13 @@ The result is:
 
 ```json
 {
-    "path": "lst/users/volodymyr_savchenko_epfl_ch/filelists/latest-file-list",
-    "status": "uploaded",
-    "total_written": 60098730
+  "path": "lst/users/volodymyr_savchenko_epfl_ch/filelists/latest-file-list",
+  "status": "uploaded",
+  "total_written": 60098730
 }
 ```
 
-Note that for every user, the file is uploaded to their own directory constructed from the user name. The path specified is relative to this directory. If you need to move the files to common directories, please as support.  But you likely want to just share returned path to be used as so:
+Note that for every user, the file is uploaded to their own directory constructed from the user name. The path specified is relative to this directory. If you need to move the files to common directories, please as support. But you likely want to just share returned path to be used as so:
 
 ```python
 ctadata.fetch_and_save_file("lst/users/volodymyr_savchenko_epfl_ch/filelists/latest-file-list")
@@ -90,6 +91,7 @@ The rest is similar to the previous case:
 ```python
 import os
 os.environ["CTADS_URL"] = "DATA-DISTRIBUTING-JUPYTERHUB/services/downloadservice/"
+os.environ["CTACS_URL"] = "DATA-DISTRIBUTING-JUPYTERHUB/services/certificateservice/"
 os.environ["JUPYTERHUB_API_TOKEN"] = "INSERT-YOUR-TOKEN-HERE"
 
 for url in ctadata.list_dir("cta/DL1/20241114/v0.1"):

--- a/ctadata/api.py
+++ b/ctadata/api.py
@@ -68,7 +68,9 @@ class APIClient:
             'chunk_size': chunk_size
         }
 
-        return requests.get(full_url, params=params, stream=stream)
+        return requests.get(
+            full_url, params=params, stream=stream,
+            headers={'Authorization': 'Bearer ' + (self.token or '')})
 
     def webdav4_client(self):
         class HeaderAuth(httpx.Auth):
@@ -86,7 +88,7 @@ class APIClient:
         )
         return client
 
-    def list_dir(self, path, token=None, downloadservice=None):
+    def list_dir(self, path):
         r = self.get_endpoint('list', path)
 
         if r.status_code != 200:

--- a/ctadata/api.py
+++ b/ctadata/api.py
@@ -34,9 +34,10 @@ class APIClient:
                       'chunk_size']
 
     downloadservice = os.getenv(
-        "CTADS_URL", "http://hub:5000/services/downloadservice/")
+        "CTADS_URL", "https://platform.cta.cscs.ch/services/downloadservice/")
     certificateservice = os.getenv(
-        "CTACS_URL", "http://hub:5001/services/certificateservice/")
+        "CTACS_URL",
+        "https://platform.cta.cscs.ch/services/certificateservice/")
     optional_url_parts = ["services/downloadservice/"]
 
     chunk_size = 10 * 1024 * 1024

--- a/ctadata/cli.py
+++ b/ctadata/cli.py
@@ -12,9 +12,11 @@ def cli(ctx):
     ctx.obj['api'] = APIClient()
     ctx.obj['api'].token = os.getenv("JUPYTERHUB_API_TOKEN")
     ctx.obj['api'].downloadservice = os.getenv(
-        "CTADS_URL", "https://platform.cta.cscs.ch/services/downloadservice/")
+        "CTADS_URL",
+        "https://platform.cta.cscs.ch/services/downloadservice/")
     ctx.obj['api'].certificateservice = os.getenv(
-        "CTACS_URL", "https://platform.cta.cscs.ch/services/certificateservice/")
+        "CTACS_URL",
+        "https://platform.cta.cscs.ch/services/certificateservice/")
     logging.basicConfig(level='INFO')
 
 

--- a/ctadata/cli.py
+++ b/ctadata/cli.py
@@ -12,7 +12,9 @@ def cli(ctx):
     ctx.obj['api'] = APIClient()
     ctx.obj['api'].token = os.getenv("JUPYTERHUB_API_TOKEN")
     ctx.obj['api'].downloadservice = os.getenv(
-        "CTADS_URL", "http://hub:5000/services/downloadservice/")
+        "CTADS_URL", "https://platform.cta.cscs.ch/services/downloadservice/")
+    ctx.obj['api'].certificateservice = os.getenv(
+        "CTACS_URL", "https://platform.cta.cscs.ch/services/certificateservice/")
     logging.basicConfig(level='INFO')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctadata"
-version = "0.4.3"
+version = "0.4.4"
 description = ""
 authors = ["Volodymyr Savchenko <contact@volodymyrsavchenko.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ctadata"
-version = "0.4.4"
+version = "0.4.5"
 description = ""
 authors = ["Volodymyr Savchenko <contact@volodymyrsavchenko.com>"]
 readme = "README.md"


### PR DESCRIPTION
As urls are configured correctly in jupyterhub, I propose to directly configure the default to be able to work from outside Jupyterhub.