### PR TITLE
Fix bug with fetch file

### DIFF
--- a/ctadata/api.py
+++ b/ctadata/api.py
@@ -355,7 +355,7 @@ class APIClient:
                 path = path[:-1]
             root_dir_name = path.split('/')[-1]
             for entry in self.list_dir(path, recursive=True):
-                print('entry', entry)
+                logger.debug('Processing entry: %s', entry)
                 save_path = entry[len(path) - len(root_dir_name):].strip()
                 dir_path = os.path.dirname(save_path)
                 if len(dir_path) > 0:

--- a/ctadata/api.py
+++ b/ctadata/api.py
@@ -360,7 +360,7 @@ class APIClient:
                 dir_path = os.path.dirname(save_path)
                 if len(dir_path) > 0:
                     os.makedirs(dir_path, exist_ok=True)
-                self.fetch_and_save_file(path, save_to_fn=save_path)
+                self.fetch_and_save_file(entry, save_to_fn=save_path)
 
     def upload_file(self, local_fn: str, path: str):
         if not path.startswith('/'):


### PR DESCRIPTION
The entire `path` is downloaded repeatedly instead of the specific `entry`

